### PR TITLE
first_year to year__gte and last_year to year__lte

### DIFF
--- a/R/get_FN011.R
+++ b/R/get_FN011.R
@@ -21,7 +21,7 @@
 ##' @export
 ##' @examples
 ##'
-##' fn011 <- get_FN011(list(lake='ON', first_year=2012, last_year=2018))
+##' fn011 <- get_FN011(list(lake='ON', year__gte=2012, year__lte=2018))
 ##'
 ##' fn011 <- get_FN011(list(lake='ER', protocol='TWL'))
 ##'

--- a/README.Rmd
+++ b/README.Rmd
@@ -61,7 +61,7 @@ year, protocol, ect.
 
 ```{r fn011}
 
-fn011 <- get_FN011(list(lake = "ON", first_year = 2012, last_year = 2018))
+fn011 <- get_FN011(list(lake = "ON", year__gte = 2012, year__lte = 2018))
 fn011 <- anonymize(fn011)
 nrow(fn011)
 head(fn011)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ such as project code, or part of the project code, lake, first year,
 last year, protocol, ect.
 
 ``` r
-fn011 <- get_FN011(list(lake = "ON", first_year = 2012, last_year = 2018))
+fn011 <- get_FN011(list(lake = "ON", year__gte = 2012, year__lte = 2018))
 fn011 <- anonymize(fn011)
 nrow(fn011)
 #> [1] 7

--- a/man/get_FN011.Rd
+++ b/man/get_FN011.Rd
@@ -30,7 +30,7 @@ for the full list of available filter keys (query parameters)
 }
 \examples{
 
-fn011 <- get_FN011(list(lake='ON', first_year=2012, last_year=2018))
+fn011 <- get_FN011(list(lake='ON', year__gte=2012, year__lte=2018))
 
 fn011 <- get_FN011(list(lake='ER', protocol='TWL'))
 


### PR DESCRIPTION
changed first_year to year__gte and last_year to year__lte in examples and README files to align with other filter conventions