### PR TITLE
typos in function documentation

### DIFF
--- a/R/check_filters.R
+++ b/R/check_filters.R
@@ -1,6 +1,6 @@
 #' Check the filters against api filters
 #'
-#' This function is used within data fetching funtions to verify that
+#' This function is used within data fetching functions to verify that
 #' the list of provided filters are known to exist.  If a filter
 #' cannot be found, a warning is printed out the screen. If the global
 #' api filter object does exist, it is populated before proceeding.

--- a/R/fetch_tfat_lookups.R
+++ b/R/fetch_tfat_lookups.R
@@ -2,7 +2,7 @@
 #'
 #' This is a helper function that is used to fetch the lookup values from tfat.
 #' Tfat exposes a lookup endpoint that returns a json response that contains
-#' key-value pairs for a number of elements associated wth fish tagging - tag
+#' key-value pairs for a number of elements associated with fish tagging - tag
 #' types, tag colours, tagging agency etc.  This function calls that endpoint
 #' and returns the results as a named list - one list for each key-value pair.
 #' This function is not intended to be called directly, but is called by other,

--- a/R/get_FN011.R
+++ b/R/get_FN011.R
@@ -1,14 +1,14 @@
 #' Get FN011 - Project meta data from FN_Portal API
 #'
 #' This function accesses the api endpoint to for FN011
-#' records. FN011 records contiain the hi-level meta data about an
-#' OMNR netting project.  The FN011 record contain information like
+#' records. FN011 records contain the hi-level meta data about an
+#' OMNR netting project.  The FN011 records contain information like
 #' project code, project name, projet leader, start and end date,
 #' protocol, and the lake where the project was conducted.  This
 #' function takes an optional filter list which can be used to return
 #' record based on several attributes of the project such as
 #' project code, or part of the project code, lake, first year, last
-#' year, protocol, ect.
+#' year, protocol, etc.
 #'
 #' See
 #' http://10.167.37.157/fn_portal/redoc/#operation/fn_011_list

--- a/R/get_FN121.R
+++ b/R/get_FN121.R
@@ -3,7 +3,7 @@
 #' This function accesses the api endpoint to for FN121
 #' records. FN121 records contain information about net sets or more
 #' generally sampling events in OMNR netting projects.  The FN121
-#' record contain information like set and lift date and time, effort
+#' records contain information like set and lift date and time, effort
 #' duration, gear, site depth and location.  This function takes an
 #' optional filter list which can be used to return record based on
 #' several attributes of the net set including set and lift date and

--- a/R/get_FN123.R
+++ b/R/get_FN123.R
@@ -6,7 +6,7 @@
 #' counts by species for each effort in a sample.  For most gill
 #' netting projects this corresponds to catches within a single panel
 #' of a particular mesh size within a net set (gang). Group (GRP) is
-#' occationally included to futher sub-devide the catch into user
+#' occasionally included to further sub-divide the catch into user
 #' defined groups that are usually specific to the project.  This
 #' function takes an optional filter list which can be used to return
 #' record based on several attributes of the catch including species,

--- a/R/get_FN125.R
+++ b/R/get_FN125.R
@@ -3,11 +3,11 @@
 #' This function accesses the api endpoint to for FN125
 #' records. FN125 records contain the biological data collected from
 #' individual fish sampled in assessment projects such as length,
-#' weight, sex, and maturity. For convience this end point also
+#' weight, sex, and maturity. For convenience this end point also
 #' returns data from child tables such as the 'preferred' age, and
 #' lamprey wounds.  This function takes an optional
 #' filter list which can be used to return records based on several
-#' different biologial attributes (such as size, sex, or maturity),
+#' different biological attributes (such as size, sex, or maturity),
 #' but also of the species, or group code, or attributes of
 #' the effort, the sample, or the project(s) that the
 #' samples were collected in.

--- a/R/get_FN125Lam.R
+++ b/R/get_FN125Lam.R
@@ -6,12 +6,12 @@
 #' wounds were reported as a single field (XLAM) in the FN125 table.
 #' In the early 2000 the great lakes fishery community agreed to
 #' capture lamprey wounding data in a more consistent fashion the
-#' basin, using the conventions described in Ebener etal 2006.  The
+#' basin, using the conventions described in Ebener et al. 2006.  The
 #' FN125Lam table captures data from individual lamprey wounds
 #' collected using those conventions.  A sampled fish with no
 #' observed wound will have a single record in this table (with
 #' lamijc value of 0), while fish with lamprey wounds, will have one
-#' record for every observed wound.    This function takes an optional
+#' record for every observed wound. This function takes an optional
 #' filter list which can be used to return records based on several
 #' different attributes of the wound (wound type, degree of healing,
 #' and wound size) as well as, attributes of the sampled

--- a/R/get_FN125Tags.R
+++ b/R/get_FN125Tags.R
@@ -7,8 +7,8 @@
 #' TAGDOC, TAGSTAT and TAGID.  This convention is fine as long a
 #' single biological sample only has a one tag. In recent years, it
 #' has been come increasingly common for fish to have multiple tags,
-#' or tag types associated with indiviudal sampling events. FN125Tag
-#' accomodates those events.  This function takes an optional filter
+#' or tag types associated with individudal sampling events. FN125Tag
+#' accommodates those events.  This function takes an optional filter
 #' list which can be used to return records based on several
 #' different attributes of the tag (tag type, colour, placement,
 #' agency, tag stat, and tag number) as well as, attributes of the

--- a/R/get_domain.R
+++ b/R/get_domain.R
@@ -1,13 +1,13 @@
 #' Internal func to get the domain great lake portal api's
 #'
-#' This funciton is intended to be used by all of the functions that #' call an
+#' This function is intended to be used by all of the functions that call an
 #' api endpoint exposed by the great lakes api endpoints.
-#' Each of the apis. are likely to have slightly differnt urls (tfat/api/v1,
-#' fn_portal/api/v1, ect), but a common domain. If the api domain changes in
+#' Each of the apis. are likely to have slightly different urls (tfat/api/v1,
+#' fn_portal/api/v1, etc), but a common domain. If the api domain changes in
 #' the future, (ie - the domain name changes or the #' version changes) we just
-#' need to update the value retruned by this function.
+#' need to update the value returned by this function.
 #'
-#' To use a local version of glfishr api during developement, set the
+#' To use a local version of glfishr api during development, set the
 #' local environment variable to True:
 #'
 #'     >  Sys.setenv(FN_PORTAL_DEV=TRUE)
@@ -16,7 +16,7 @@
 # port 8000, but these can be changed by setting the #' environment variables
 # FN_PORTAL_HOST, FN_PORTAL_PORT to the #' appropriate host and port number.
 #'
-#'      >  Sys.setenv(FN_PORTAL_HOST='<some-ip-address>')
+#'      > Sys.setenv(FN_PORTAL_HOST='<some-ip-address>')
 #'      > Sys.setenv(FN_PORTAL_PORT=8080)
 #'
 #' @author Adam Cottrill \email{adam.cottrill@@ontario.ca}

--- a/R/get_fn_portal_root.R
+++ b/R/get_fn_portal_root.R
@@ -1,9 +1,9 @@
 #' Internal function to url to the FN_Portal api.
 #'
-#' This funciton is intended to be used by all of the functions that call an
+#' This function is intended to be used by all of the functions that call an
 #' api endpoint exposed by fn_portal. Each of the portals (tfat, sc_portal, fn_portal etc.)
 #' all have a slightly different access point, and each will have a similar
-#' function. If the api enpoint for that portal changes in the future, (.i.e.
+#' function. If the api endpoint for that portal changes in the future, (i.e.
 #' the  version changes) we just need to update the value in this file and all
 #' of the dependent functions will use it.  Note that the url string does
 #' *NOT* include a trailing slash.

--- a/R/get_tfat_encounters.R
+++ b/R/get_tfat_encounters.R
@@ -4,7 +4,7 @@
 #' events were tags were either applied or re-captured during OMNR field
 #' projects. (excluding CWTs). The TFAT encounter information contains all of
 #' the information required to analyze  tagging data, but they are not the
-#' definative record for biological samples, and do not contain any informatin
+#' definitive record for biological samples, and do not contain any information
 #' about other fish caught in the same sampling event.  See Project Tracker for
 #' more information about tagging projects and FN_Portal(and other master
 #' databases) to access the complete dataset.

--- a/R/get_tfat_recoveries.R
+++ b/R/get_tfat_recoveries.R
@@ -3,7 +3,7 @@
 #' This function accesses the TFAT api endpoint to for tag recoveries - tags
 #' reported by anglers, the general public, or other agencies.  Tag Recovery
 #' events include information about the tag, the tagged fish, and where the
-#' recovery occured.
+#' recovery occurred.
 #'
 #' This function takes an optional filter list which can be used to return
 #' records based on several attributes of the tagged fish (species, or size),

--- a/R/get_tfat_reports.R
+++ b/R/get_tfat_reports.R
@@ -2,7 +2,7 @@
 #'
 #' This function accesses the TFAT api endpoint for tag reports - tag reports
 #' are anglers, the general public, or other agencies.  A tag report can have
-#' one or many associated tags (ie. tag recoveries).  Every tag recovery has
+#' one or many associated tags (i.e. tag recoveries).  Every tag recovery has
 #' only one tag report. Tag reports include the reporting date and method, and
 #' whether or not a follow-up letter  was requested.
 #'

--- a/R/show_filters.R
+++ b/R/show_filters.R
@@ -2,7 +2,7 @@
 #'
 #' Most of the fn_portal API endpoints have a large number of
 #' available filters.  This function takes and api endpoint name and
-#' prints out all of the avaiable filters.  If 'filter_like' is
+#' prints out all of the available filters.  If 'filter_like' is
 #' provided, only those filters that contain the provided string are
 #' printed.
 #'


### PR DESCRIPTION
minor edits to fix typos in documentation found while I was reading the function source code.