### PR TITLE
Added uncount_tally() function to 'uncount' the FN124 table

### DIFF
--- a/R/exceed_limit.R
+++ b/R/exceed_limit.R
@@ -23,7 +23,7 @@
 #' 
 #' FN122_NA1 <- exceed_limit(get_FN122, FN011$PRJ_CD, list(gr = "NA1"))
 #' 
-#' FN125_NA1 <- exceed_limit(get_FN125, FN011$PRJ_CD, list(gr = "NA1"))
+#' FN125_NA1 <- exceed_limit(get_FN125, FN011$PRJ_CD, list(spc = c(121, 331, 334)))
 exceed_limit <- function(get_fun, prj_cds, extra_filters_as_list = NULL) {
   
   df_list <- lapply(1:length(prj_cds), function(i) {

--- a/R/get_FN124.R
+++ b/R/get_FN124.R
@@ -1,15 +1,15 @@
 
 #' Get FN124 - Length Frequency Counts from FN_Portal API
 #'
-#' This function accesses the api endpoint to for FN124 records from
+#' This function accesses the api endpoint for FN124 records from
 #' the FN_Portal. FN124 records contain information about the length frequency
-#' by species for each effort in a sample.  For most gill
+#' by species for each effort in a sample. For most gill
 #' netting projects this corresponds to catches within a single panel
 #' of a particular mesh size within a net set (gang). Group (GRP) is
 #' occasionally included to further sub-divide the catch into user
-#' defined groups that are usually specific to the project.  This
+#' defined groups that are usually specific to the project. This
 #' function takes an optional filter list which can be used to return
-#' record based on several attributes of the catch including species,
+#' record based on several attributes of the catch including species
 #' or group code but also attributes of the effort, the sample or the
 #' project(s) that the catches were made in.
 #'
@@ -29,7 +29,7 @@
 #' @export
 #' @examples
 #'
-#' fn123 <- get_FN124(list(lake = "ON", year = 2012, spc = "334", gear = "GL"))
+#' fn124 <- get_FN124(list(lake = "ON", year = 2021, spc = "334"))
 #'
 #' filters <- list(
 #'   lake = "ON",
@@ -39,7 +39,9 @@
 #'   sidep__lte = 40
 #' )
 #' fn124 <- get_FN124(filters)
-get_FN124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
+#'
+#' LOA_IA21_TW1 <- get_FN124(list(prj_cd = "LHA_IA21_TW1"), uncount = TRUE)
+get_FN124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE, uncount = FALSE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("fn124", filter_list)
@@ -50,6 +52,11 @@ get_FN124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
+
+  if (uncount == TRUE) {
+    payload <- uncount_tally(payload, "SIZCNT")
+    return(payload)
+  }
 
   return(payload)
 }

--- a/R/uncount_tally.R
+++ b/R/uncount_tally.R
@@ -1,0 +1,23 @@
+#' Uncount Tallies
+#' 
+#' This function "uncounts" a tally, duplicating each row a number of times
+#' equal to the value in the selected tally column. It is a simplified version
+#' of the tidyr function uncount(). 
+#'
+#' @param df FN124 table fetched from GLIS using get_FN124()
+#' @param tally_col Column name where the tally is stored; enter as a string
+#'
+#' @return
+#' @export
+#'
+#' @examples 
+#' LOA_IA21_TW1 <- get_FN124(list(prj_cd = "LOA_IA21_TW1"))
+#' LOA_IA21_TW1_long <- uncount_tally(LOA_IA21_TW1, "SIZCNT")
+uncount_tally <- function(df, tally_col){
+  
+  long_df <- df[rep(seq(nrow(df)), df[[tally_col]]), names(df) != tally_col]
+  
+  rownames(long_df) <- NULL
+  
+  return(long_df)
+}


### PR DESCRIPTION
Added uncount_tally() function to 'uncount' the FN124 table (or any tally). Added uncount = FALSE to get_FN124 to select if records should be tallied or not.

Minor fix to exceed_limit examples.