### PR TITLE
Adjust description for fetch_pt_associated_files

### DIFF
--- a/R/fetch_pt_associated_files.R
+++ b/R/fetch_pt_associated_files.R
@@ -1,19 +1,14 @@
 #' fetch_pt_associated_files - Project Tracker Reports
 #'
-#' This function accesses the api endpoint to for associated files that have
+#' This function accesses the api endpoint for associated files that have
 #' been uploaded to project tracker.  This api endpoint accepts a
-#' large number of filters associated with the project or report type.
+#' large number of filters associated with the project.
 #' Project specific filters include project code(s), years, lakes, and
-#' project lead.  Reports can also be filtered by their associated
-#' milestone.  Valid report types are: "Prj Prop", "Prj Prop Pres",
-#' "procvallog", "ProjDescPres", "Prj Desc", "Protocol",
-#' "Field Report", "Prj Comp Rep", "Prj Comp Pres", "Sum Rep", and
-#' "Creel Estimates" . Use 'show_filter("reports")' to see the full list
-#' of available filters.  This function returns a dataframe containing
-#' attributes of the report, including project code, report type, and
-#' the path to the report on the server. It is often uses in
-#' conjunction with [fetch_pt_associated_files()] to actually download the
-#' selected reports to a target directory.
+#' project lead.  Use 'show_filters("associated_files")' to see the full list
+#' of available filters.  This function is used to download any files in the
+#' associated files section of project tracker to a specified target directory.
+#' It is often used in conjunction with [get_pt_associated_files()] which returns
+#' a dataframe containing attributes of the upload files.
 #'
 #' @param filter_list list - the filters used to select the projects
 #' and reports to be downloaded from the server.
@@ -37,20 +32,20 @@
 #' \donttest{
 #' reports <- fetch_pt_associated_files(list(
 #'   lake = "ON", year__gte = 2012,
-#'   year__lte = 2018
-#' ))
+#'   year__lte = 2018),
+#'   target_dir = '~/Target Folder Name')
 #'
 #' reports <- fetch_pt_associated_files(list(
 #'   lake = "HU", year__gte = 2012,
-#'   prj_cd__like = "006", report_type = "prtocol"
-#' ))
+#'   prj_cd__like = "006"),
+#'   target_dir = '~/Target Folder Name')
 #'
-#' reports <- fetch_pt_associated_files(list(lake = "ER", protocol = "TWL"))
+#' reports <- fetch_pt_associated_files(list(lake = "ER", protocol = "TWL"), target_dir = '~/Target Folder Name')
 #'
 #' filters <- list(lake = "SU", prj_cd = c("LSA_IA15_CIN", "LSA_IA17_CIN"))
-#' reports <- fetch_pt_associated_files(filters)
+#' reports <- fetch_pt_associated_files(filters, target_dir = '~/Target Folder Name')
 #'
-#' reports <- fetch_pt_associated_files(list(lake = "HU", protocol = "USA"))
+#' reports <- fetch_pt_associated_files(list(lake = "HU", protocol = "USA"), target_dir = '~/Target Folder Name')
 #' }
 #'
 fetch_pt_associated_files <- function(filter_list, target_dir,


### PR DESCRIPTION
The following changes were made, with associated rationale:

- Fixed spelling errors.
- Adjusted the description to match 'get_pt_associated_files' instead of 'get_pt_reports' This included removing anything associated with report types. The 'get_pt_associated_files' function does not support the 'report_type' filter.
- Added 'target_dir' to all examples (with an example file path). A target directory is required for this function to work.

No changes to actual code.