### PR TITLE
Adjust description for fetch_pt_reports

### DIFF
--- a/R/fetch_pt_reports.R
+++ b/R/fetch_pt_reports.R
@@ -1,19 +1,18 @@
 #' fetch_pt_reports - Project Tracker Reports
 #'
-#' This function accesses the api endpoint to for associated files that have
-#' been uploaded to project tracker.  This api endpoint accepts a
+#' This function accesses the api endpoint for files associated with core reporting
+#' requirements that have been uploaded to project tracker.  This api endpoint accepts a
 #' large number of filters associated with the project or report type.
 #' Project specific filters include project code(s), years, lakes, and
 #' project lead.  Reports can also be filtered by their associated
 #' milestone.  Valid report types are: "Prj Prop", "Prj Prop Pres",
 #' "procvallog", "ProjDescPres", "Prj Desc", "Protocol",
 #' "Field Report", "Prj Comp Rep", "Prj Comp Pres", "Sum Rep", and
-#' "Creel Estimates" . Use 'show_filter("reports")' to see the full list
-#' of available filters.  This function returns a dataframe containing
-#' attributes of the report, including project code, report type, and
-#' the path to the report on the server. It is often uses in
-#' conjunction with [fetch_pt_reports()] to actually download the
-#' selected reports to a target directory.
+#' "Creel Estimates". Use 'show_filters("reports")' to see the full list
+#' of available filters.  This function is used to download selected files
+#' to a specified target directory.  It is often used in
+#' conjunction with [get_pt_reports()] which returns
+#' a dataframe containing attributes of the upload files.
 #'
 #'
 #' @param filter_list list - the filters used to select the projects
@@ -38,20 +37,20 @@
 #' \donttest{
 #' reports <- fetch_pt_reports(list(
 #'   lake = "ON", year__gte = 2012,
-#'   year__lte = 2018
-#' ))
+#'   year__lte = 2018),
+#'   target_dir = '~/Target Folder Name')
 #'
 #' reports <- fetch_pt_reports(list(
 #'   lake = "HU", year__gte = 2012,
-#'   prj_cd__like = "006", report_type = "prtocol"
-#' ))
+#'   prj_cd__like = "006", report_type = "Protocol"),
+#'   target_dir = '~/Target Folder Name')
 #'
-#' reports <- fetch_pt_reports(list(lake = "ER", protocol = "TWL"))
+#' reports <- fetch_pt_reports(list(lake = "ER", protocol = "TWL"), target_dir = '~/Target Folder Name')
 #'
 #' filters <- list(lake = "SU", prj_cd = c("LSA_IA15_CIN", "LSA_IA17_CIN"))
-#' reports <- fetch_pt_reports(filters)
+#' reports <- fetch_pt_reports(filters, target_dir = '~/Target Folder Name')
 #'
-#' reports <- fetch_pt_reports(list(lake = "HU", protocol = "USA"))
+#' reports <- fetch_pt_reports(list(lake = "HU", protocol = "USA"), target_dir = '~/Target Folder Name')
 #' }
 #'
 fetch_pt_reports <- function(filter_list, target_dir,


### PR DESCRIPTION
The following changes were made, with associated rationale:

- Fixed spelling errors.
- Adjusted the description to highlight that this function is used to download files. It was previously describing the functionality of get_pt_reports.
- Added 'target_dir' to all examples (with an example file path). A target directory is required for this function to work.

No changes to actual code.