### PR TITLE
trycatch in get_credentials, style_pkg() changes

### DIFF
--- a/R/api_to_dataframe.R
+++ b/R/api_to_dataframe.R
@@ -20,14 +20,14 @@
 
 
 api_to_dataframe <- function(url, data = NULL, page = 0, recursive = TRUE) {
-  if(!exists("token")) token <- get_token()
+  if (!exists("token")) token <- get_token()
 
-  auth_header = sprintf("Token %s", token) 
-  
+  auth_header <- sprintf("Token %s", token)
+
   max_page_count <- 10
   url <- gsub("\\n", " ", url)
   url <- utils::URLencode(url)
-  #response <- tryCatch(httr::GET(url),
+  # response <- tryCatch(httr::GET(url),
   response <- tryCatch(httr::GET(url, httr::add_headers(authorization = auth_header)),
     error = function(err) {
       print("unable to fetch from the server. Is your VPN active?")
@@ -56,8 +56,8 @@ api_to_dataframe <- function(url, data = NULL, page = 0, recursive = TRUE) {
       "different filters and combine them in R."
     ))
   }
-  
-  if(is.null(token[["token"]])){
+
+  if (is.null(token[["token"]])) {
     warning(paste0(
       "Your token was not retrieved successfully and some data may be hidden. \n",
       "Run get_token() to re-enter your credentials."

--- a/R/check_filters.R
+++ b/R/check_filters.R
@@ -9,7 +9,7 @@
 #' @param filters - list of filter names that are to be applied to the
 #'   endpoint.
 #' @param api_app - the name of the api application to fetch the
-#' filters from. 
+#' filters from.
 #'
 #' @author Adam Cottrill \email{adam.cottrill@@ontario.ca}
 #' @return list
@@ -21,16 +21,15 @@
 #' check_filters("common_filters", c("mu_type", "taxon_name"))
 #' check_filters("foo", c("year", "prj_cd"))
 check_filters <- function(endpoint, filters, api_app) {
-  
   if (!exists("api_filters")) get_api_filters(api_app = api_app)
-  
+
   endpoint <- tolower(endpoint)
 
   known_filters <- api_filters[[endpoint]]
   if (is.null(known_filters)) {
     known_filters <- refresh_filters(endpoint, api_app = api_app)
   }
-  
+
   diff <- setdiff(names(filters), known_filters$name)
   if (length(diff)) {
     tmp <- paste(diff, collapse = "\n + ")

--- a/R/exceed_limit.R
+++ b/R/exceed_limit.R
@@ -13,11 +13,15 @@
 #' @export
 #'
 #' @examples
-#' FN011 <- get_FN011(list(protocol = "BSM", lake = "HU",
-#' prj_cd__not = "LHR_IA17_819", prj_cd__not_like = "BM"))
+#' FN011 <- get_FN011(list(
+#'   protocol = "BSM", lake = "HU",
+#'   prj_cd__not = "LHR_IA17_819", prj_cd__not_like = "BM"
+#' ))
 #'
-#' my_projects <- list("LHA_IA19_802", "LHA_IA19_810", "LHA_IA19_811",
-#' "LHA_IA19_812", "LHA_IA19_813", "LHA_IA19_814")
+#' my_projects <- list(
+#'   "LHA_IA19_802", "LHA_IA19_810", "LHA_IA19_811",
+#'   "LHA_IA19_812", "LHA_IA19_813", "LHA_IA19_814"
+#' )
 #'
 #' FN122 <- exceed_limit(get_FN122, FN011$PRJ_CD)
 #'
@@ -25,8 +29,10 @@
 #'
 #' FN122_NA1 <- exceed_limit(get_FN122, FN011$PRJ_CD, list(gr = "NA1"))
 #'
-#' FN125_NA1 <- exceed_limit(get_FN125, FN011$PRJ_CD,
-#' list(spc = c(121, 331, 334)))
+#' FN125_NA1 <- exceed_limit(
+#'   get_FN125, FN011$PRJ_CD,
+#'   list(spc = c(121, 331, 334))
+#' )
 exceed_limit <- function(get_fun, prj_cds, extra_filters_as_list = NULL) {
   df_list <- lapply(1:length(prj_cds), function(i) {
     base_filter <- list(prj_cd = prj_cds[i])

--- a/R/fetch_pt_associated_files.R
+++ b/R/fetch_pt_associated_files.R
@@ -32,20 +32,24 @@
 #' \donttest{
 #' reports <- fetch_pt_associated_files(list(
 #'   lake = "ON", year__gte = 2012,
-#'   year__lte = 2018),
-#'   target_dir = '~/Target Folder Name')
+#'   year__lte = 2018
+#' ),
+#' target_dir = "~/Target Folder Name"
+#' )
 #'
 #' reports <- fetch_pt_associated_files(list(
 #'   lake = "HU", year__gte = 2012,
-#'   prj_cd__like = "006"),
-#'   target_dir = '~/Target Folder Name')
+#'   prj_cd__like = "006"
+#' ),
+#' target_dir = "~/Target Folder Name"
+#' )
 #'
-#' reports <- fetch_pt_associated_files(list(lake = "ER", protocol = "TWL"), target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_associated_files(list(lake = "ER", protocol = "TWL"), target_dir = "~/Target Folder Name")
 #'
 #' filters <- list(lake = "SU", prj_cd = c("LSA_IA15_CIN", "LSA_IA17_CIN"))
-#' reports <- fetch_pt_associated_files(filters, target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_associated_files(filters, target_dir = "~/Target Folder Name")
 #'
-#' reports <- fetch_pt_associated_files(list(lake = "HU", protocol = "USA"), target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_associated_files(list(lake = "HU", protocol = "USA"), target_dir = "~/Target Folder Name")
 #' }
 #'
 fetch_pt_associated_files <- function(filter_list, target_dir,

--- a/R/fetch_pt_reports.R
+++ b/R/fetch_pt_reports.R
@@ -37,20 +37,24 @@
 #' \donttest{
 #' reports <- fetch_pt_reports(list(
 #'   lake = "ON", year__gte = 2012,
-#'   year__lte = 2018),
-#'   target_dir = '~/Target Folder Name')
+#'   year__lte = 2018
+#' ),
+#' target_dir = "~/Target Folder Name"
+#' )
 #'
 #' reports <- fetch_pt_reports(list(
 #'   lake = "HU", year__gte = 2012,
-#'   prj_cd__like = "006", report_type = "Protocol"),
-#'   target_dir = '~/Target Folder Name')
+#'   prj_cd__like = "006", report_type = "Protocol"
+#' ),
+#' target_dir = "~/Target Folder Name"
+#' )
 #'
-#' reports <- fetch_pt_reports(list(lake = "ER", protocol = "TWL"), target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_reports(list(lake = "ER", protocol = "TWL"), target_dir = "~/Target Folder Name")
 #'
 #' filters <- list(lake = "SU", prj_cd = c("LSA_IA15_CIN", "LSA_IA17_CIN"))
-#' reports <- fetch_pt_reports(filters, target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_reports(filters, target_dir = "~/Target Folder Name")
 #'
-#' reports <- fetch_pt_reports(list(lake = "HU", protocol = "USA"), target_dir = '~/Target Folder Name')
+#' reports <- fetch_pt_reports(list(lake = "HU", protocol = "USA"), target_dir = "~/Target Folder Name")
 #' }
 #'
 fetch_pt_reports <- function(filter_list, target_dir,

--- a/R/get_FN011.R
+++ b/R/get_FN011.R
@@ -37,9 +37,10 @@
 #' fn011 <- get_FN011(list(lake = "HU", prj_cd__like = "_006"))
 #'
 #' fn011 <- get_FN011(list(lake = "HU", protocol = "USA"))
-#' fn011 <- get_FN011(list(lake = "HU", protocol = "USA"), show_id =
-#' TRUE)
-#'
+#' fn011 <- get_FN011(list(lake = "HU", protocol = "USA"),
+#'   show_id =
+#'     TRUE
+#' )
 get_FN011 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)

--- a/R/get_FN026_Subspace.R
+++ b/R/get_FN026_Subspace.R
@@ -33,9 +33,9 @@ get_FN026_Subspace <- function(filter_list = list(), show_id = FALSE, to_upper =
     get_fn_portal_root(),
     query_string
   )
-  
+
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   return(payload)
 }

--- a/R/get_FN121_Electrofishing.R
+++ b/R/get_FN121_Electrofishing.R
@@ -1,12 +1,12 @@
 #' Get FN121_Electrofishing - Electrofishing data from FN_Portal API
 #'
 #' This function accesses the api endpoint for FN121_Electrofishing
-#' records. FN121_Electrofishing records contain information about 
+#' records. FN121_Electrofishing records contain information about
 #' electrofishing sampling events, including shocking seconds, volts,
 #' amps, and power used for each SAM. Other relevant details for the SAM
-#' are found in the FN121 and optionally the FN121_GPS_Tracks tables. 
-#' This function takes an optional filter list which can be used to 
-#' return records based on attributes of the SAM including start and end 
+#' are found in the FN121 and optionally the FN121_GPS_Tracks tables.
+#' This function takes an optional filter list which can be used to
+#' return records based on attributes of the SAM including start and end
 #' date and time, effort duration, gear, site depth and location as well as
 #' attributes of the projects they are associated with such project
 #' code, or part of the project code, lake, first year, last year,
@@ -31,7 +31,7 @@
 #' show_filters("fn121electrofishing")
 #'
 #' fn121_efish_huron <- get_FN121_Electrofishing(list(lake = "HU"))
-#' 
+#'
 #' fn121_efish_500ss <- get_FN121_Electrofishing(list(shock_sec__gte = 500))
 get_FN121_Electrofishing <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)

--- a/R/get_FN121_GPS_Tracks.R
+++ b/R/get_FN121_GPS_Tracks.R
@@ -2,12 +2,12 @@
 #'
 #' This function accesses the api endpoint for FN121_GPS_Tracks
 #' records. FN121_GPS_Tracks records contain GPS tracks for projects
-#' where GPS data is recorded (e.g. trawls, electrofishing, etc.), including 
+#' where GPS data is recorded (e.g. trawls, electrofishing, etc.), including
 #' the track ID, coordinates in decimal decrees, the timestamp and site depth.
-#' Other relevant details for each SAM are found in the FN121 table. 
-#' This function takes an optional filter list which can be used to 
+#' Other relevant details for each SAM are found in the FN121 table.
+#' This function takes an optional filter list which can be used to
 #' return records based on attributes of the SAM including site depth, timestamp,
-#' start and end date and time, effort duration, gear, site depth and location 
+#' start and end date and time, effort duration, gear, site depth and location
 #' as well as attributes of the projects they are associated with such project
 #' code, or part of the project code, lake, first year, last year,
 #' protocol, etc.
@@ -28,7 +28,7 @@
 #' @export
 #' @examples
 #'
-#' TODO: Update with relevant examples when more data exists in the portal
+#' # TODO: Update with relevant examples when more data exists in the portal
 #'
 #' fn121_gps <- get_FN121_GPS_Tracks(list(lake = "HU", prj_cd__like = "_306"))
 #' fn121_gps <- get_FN121_GPS_Tracks(list(lake = "HU", prj_cd__like = "_306"), show_id = TRUE)

--- a/R/get_FN121_Trapnet.R
+++ b/R/get_FN121_Trapnet.R
@@ -1,16 +1,18 @@
 #' Get FN121_Trapnet - Trapnet data from FN_Portal API
 #'
 #' This function accesses the api endpoint for fn121trapnet
-#' records. fn121trapnet records contain details typically collected as part
-#' of the Ontario NSCIN protocol: bottom type, cover type, vegetation,
-#' and the angle, use, and distance offshore of the trap net leader.
-#' Other relevant details for each SAM are found in the FN121 table. 
-#' This function takes an optional filter list which can be used to return records 
-#' based on attributes of the SAM including site depth, start and end date 
-#' and time, effort duration, gear, and location as well as attributes of the projects 
-#' they are associated with such as project code, or part of the project code, lake, 
-#' first year, last year, protocol, etc. This function can also take filters related to 
-#' the bottom, cover, and vegetation types, and the angle/length of the leader.
+#' records. fn121trapnet records contain details typically collected
+#' as part of the Ontario NSCIN protocol: bottom type, cover type,
+#' vegetation, and the angle, use, and distance offshore of the trap
+#' net leader.  Other relevant details for each SAM are found in the
+#' FN121 table.  This function takes an optional filter list which can
+#' be used to return records based on attributes of the SAM including
+#' site depth, start and end date and time, effort duration, gear, and
+#' location as well as attributes of the projects they are associated
+#' with such as project code, or part of the project code, lake, first
+#' year, last year, protocol, etc. This function can also take filters
+#' related to the bottom, cover, and vegetation types, and the
+#' angle/length of the leader.
 #'
 #' See
 #' http://10.167.37.157/fn_portal/api/v1/redoc/#operation/fn121trapnet_list
@@ -28,7 +30,7 @@
 #' @export
 #' @examples
 #'
-#' TODO: Update with relevant examples when more data exists in the portal
+#' # TODO: Update with relevant examples when more data exists in the portal
 #'
 #' fn121_trapnet <- get_FN121_Trapnet(list(lake = "ON", year = 2022))
 get_FN121_Trapnet <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
@@ -42,6 +44,6 @@ get_FN121_Trapnet <- function(filter_list = list(), show_id = FALSE, to_upper = 
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   return(payload)
 }

--- a/R/get_FN121_Trawl.R
+++ b/R/get_FN121_Trawl.R
@@ -2,12 +2,12 @@
 #'
 #' This function accesses the api endpoint for fn121trawl
 #' records. fn121trawl records contain details on the vessel, its speed and direction,
-#' and warp. Other relevant details for each SAM are found in the FN121 table. 
-#' This function takes an optional filter list which can be used to return records 
-#' based on attributes of the SAM including site depth, start and end date 
-#' and time, effort duration, gear, and location as well as attributes of the projects 
-#' they are associated with such as project code, or part of the project code, lake, 
-#' first year, last year, protocol, etc. This function can also take filters related to 
+#' and warp. Other relevant details for each SAM are found in the FN121 table.
+#' This function takes an optional filter list which can be used to return records
+#' based on attributes of the SAM including site depth, start and end date
+#' and time, effort duration, gear, and location as well as attributes of the projects
+#' they are associated with such as project code, or part of the project code, lake,
+#' first year, last year, protocol, etc. This function can also take filters related to
 #' the vessel/warp.
 #'
 #' See
@@ -26,7 +26,7 @@
 #' @export
 #' @examples
 #'
-#' TODO: Update with relevant examples when more data exists in the portal
+#' # TODO: Update with relevant examples when more data exists in the portal
 #'
 #' fn121_trawl <- get_FN121_Trawl(list(lake = "ER", year = 2018))
 get_FN121_Trawl <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
@@ -40,6 +40,6 @@ get_FN121_Trawl <- function(filter_list = list(), show_id = FALSE, to_upper = TR
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   return(payload)
 }

--- a/R/get_FN121_Weather.R
+++ b/R/get_FN121_Weather.R
@@ -3,10 +3,10 @@
 #' This function accesses the api endpoint for fn121weather
 #' records. fn121weather records contain air temperature, precipitation,
 #' wind speed and direction, cloud cover, and wave height data collected
-#' at time/location 0 and/or 1. Other relevant details for each SAM are 
-#' found in the FN121 table. This function takes an optional filter list which can 
-#' be used to return records based on attributes of the SAM including site 
-#' depth, start and end date and time, effort duration, gear, and location 
+#' at time/location 0 and/or 1. Other relevant details for each SAM are
+#' found in the FN121 table. This function takes an optional filter list which can
+#' be used to return records based on attributes of the SAM including site
+#' depth, start and end date and time, effort duration, gear, and location
 #' as well as attributes of the projects they are associated with such as project
 #' code, or part of the project code, lake, first year, last year,
 #' protocol, etc. This function can also take filters related to weather.
@@ -27,7 +27,7 @@
 #' @export
 #' @examples
 #'
-#' TODO: Update with relevant examples when more data exists in the portal
+#' # TODO: Update with relevant examples when more data exists in the portal
 #'
 #' fn121_weather <- get_FN121_Weather(list(lake = "ER", year = 2018))
 get_FN121_Weather <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
@@ -41,6 +41,6 @@ get_FN121_Weather <- function(filter_list = list(), show_id = FALSE, to_upper = 
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   return(payload)
 }

--- a/R/get_FN124.R
+++ b/R/get_FN124.R
@@ -45,8 +45,8 @@
 #' fn124 <- get_FN124(filters)
 #'
 #' LOA_IA21_TW1 <- get_FN124(list(prj_cd = "LOA_IA21_TW1"),
-#'     uncount = TRUE)
-#'
+#'   uncount = TRUE
+#' )
 get_FN124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE, uncount = FALSE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)

--- a/R/get_FN125_Lamprey.R
+++ b/R/get_FN125_Lamprey.R
@@ -54,7 +54,7 @@
 #' fn125Lam <- get_FN125_Lamprey(filters)
 #' fn125Lam <- get_FN125_Lamprey(filters, show_id = TRUE)
 get_FN125_Lamprey <- function(filter_list = list(), show_id = FALSE,
-                         to_upper = TRUE) {
+                              to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("fn125lamprey", filter_list, "fn_portal")

--- a/R/get_FN125_Tags.R
+++ b/R/get_FN125_Tags.R
@@ -44,7 +44,7 @@
 #' fn125_Tags <- get_FN125_Tags(filters)
 #' fn125_Tags <- get_FN125_Tags(filters, show_id = TRUE)
 get_FN125_Tags <- function(filter_list = list(), show_id = FALSE,
-                          to_upper = TRUE) {
+                           to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("fn125tags", filter_list, "fn_portal")

--- a/R/get_SC011.R
+++ b/R/get_SC011.R
@@ -9,7 +9,7 @@
 #' records based on several attributes of the project such as
 #' project code, or part of the project code, lake, first year, last
 #' year, contact, etc.
-#' 
+#'
 #' Use ~show_filters("sc011")~ to see the full list of available filter
 #' keys (query parameters)
 #'

--- a/R/get_SC012.R
+++ b/R/get_SC012.R
@@ -41,6 +41,6 @@ get_SC012 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   return(payload)
 }

--- a/R/get_SC124.R
+++ b/R/get_SC124.R
@@ -40,8 +40,8 @@
 #' sc124 <- get_SC124(filters)
 #'
 #' sc124 <- get_SC124(list(prj_cd = "LOA_SC19_002"),
-#'     uncount = TRUE)
-#'
+#'   uncount = TRUE
+#' )
 get_SC124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE, uncount = FALSE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
@@ -53,11 +53,11 @@ get_SC124 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE, un
   )
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, show_id, to_upper)
-  
+
   if (uncount == TRUE) {
     payload <- uncount_tally(payload, "SIZCNT")
     return(payload)
   }
-  
+
   return(payload)
 }

--- a/R/get_SC125_Lamprey.R
+++ b/R/get_SC125_Lamprey.R
@@ -40,7 +40,7 @@
 #' sc125Lam <- get_SC125_Lamprey(filters)
 #' sc125Lam <- get_SC125_Lamprey(filters, show_id = TRUE)
 get_SC125_Lamprey <- function(filter_list = list(), show_id = FALSE,
-                         to_upper = TRUE) {
+                              to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("sc125lamprey", filter_list, api_app = "creels")

--- a/R/get_SC125_Tags.R
+++ b/R/get_SC125_Tags.R
@@ -35,7 +35,7 @@
 #' sc125Tags <- get_SC125_Tags(filters)
 #' sc125Tags <- get_SC125_Tags(filters, show_id = TRUE)
 get_SC125_Tags <- function(filter_list = list(), show_id = FALSE,
-                          to_upper = TRUE) {
+                           to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("sc125tags", filter_list, api_app = "creels")

--- a/R/get_ageprep1.R
+++ b/R/get_ageprep1.R
@@ -1,18 +1,18 @@
 #' Get age preparation 1 options - A list of age preparation 1 codes used in GLIS
 #'
 #' This function accesses the api endpoint for age preparation 1 choices and returns
-#' their labels, descriptions and whether they're in use. It fetches the entire 
-#' table of valid age preparation 1 codes - no other 
-#' filter parameters are currently available for this endpoint. 
-#' 
+#' their labels, descriptions and whether they're in use. It fetches the entire
+#' table of valid age preparation 1 codes - no other
+#' filter parameters are currently available for this endpoint.
+#'
 #' Note that age preparation 1 codes are valid for the second
-#' character of the AGEMT field. 
-#' 
+#' character of the AGEMT field.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/agepre1
 #' for the full list of age preparation 1 code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -29,9 +29,9 @@
 get_ageprep1 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("ageprep1", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("ageprep1", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/ageprep1/%s",
     common_api_url,

--- a/R/get_ageprep2.R
+++ b/R/get_ageprep2.R
@@ -1,18 +1,18 @@
 #' Get age preparation 2 options - A list of age preparation 2 codes used in GLIS
 #'
 #' This function accesses the api endpoint for age preparation 2 choices and returns
-#' their labels, descriptions and whether they're in use. It fetches the entire 
-#' table of valid age preparation 2 codes - no other 
-#' filter parameters are currently available for this endpoint. 
-#' 
+#' their labels, descriptions and whether they're in use. It fetches the entire
+#' table of valid age preparation 2 codes - no other
+#' filter parameters are currently available for this endpoint.
+#'
 #' Note that age preparation 2 codes are valid for the second
-#' character of the AGEMT field. 
-#' 
+#' character of the AGEMT field.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/ageprep2
 #' for the full list of age preparation 2 code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -29,9 +29,9 @@
 get_ageprep2 <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("ageprep2", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("ageprep2", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/ageprep2/%s",
     common_api_url,

--- a/R/get_agest.R
+++ b/R/get_agest.R
@@ -1,19 +1,19 @@
 #' Get aging structure options - A list of aging structure codes used in GLIS
 #'
 #' This function accesses the api endpoint for aging structure choices and returns
-#' their labels, descriptions and whether they're in use. It can fetch the entire 
-#' table of valid aging structures, or it accepts the filter parameter all=TRUE 
-#' to return all aging structures, including those no longer in use. No other 
-#' filter parameters are currently available for this endpoint. 
-#' 
+#' their labels, descriptions and whether they're in use. It can fetch the entire
+#' table of valid aging structures, or it accepts the filter parameter all=TRUE
+#' to return all aging structures, including those no longer in use. No other
+#' filter parameters are currently available for this endpoint.
+#'
 #' Note that aging structures are valid for the AGEST field and the first
-#' character of the AGEMT field. 
-#' 
+#' character of the AGEMT field.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/aging_structures
 #' for the full list of aging structure code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -31,9 +31,9 @@
 get_agest <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("age_structure", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("age_structure", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/age_structure/%s",
     common_api_url,

--- a/R/get_bottom_types.R
+++ b/R/get_bottom_types.R
@@ -5,12 +5,12 @@
 #' the entire table of accepted bottom type codes, or it accepts filter parameter
 #' all=TRUE to return depreciated bottom type codes too. No other filter
 #' parameters are currently available for this endpoint.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/bottom_types
 #' for the full list of bottom types
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -23,14 +23,14 @@
 #' @examples
 #'
 #' bottom_types <- get_bottom_types()
-#' all_bottom_types <- get_bottom_types(list(all=TRUE))
+#' all_bottom_types <- get_bottom_types(list(all = TRUE))
 #' bottom_type_slugs <- get_bottom_types(show_id = TRUE)
 get_bottom_types <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("bottom_types", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("bottom_types", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/bottom_types/%s",
     common_api_url,

--- a/R/get_clip_codes.R
+++ b/R/get_clip_codes.R
@@ -5,12 +5,12 @@
 #' the entire table of clip codes - no other filter
 #' parameters are currently available for this endpoint. The same list of
 #' clip codes are available for CLIPA and CLIPC.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/finclips
 #' for the full list of clip code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -27,9 +27,9 @@
 get_clip_codes <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("clip_capture", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("clip_capture", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/clip_capture/%s",
     common_api_url,

--- a/R/get_cover_types.R
+++ b/R/get_cover_types.R
@@ -5,12 +5,12 @@
 #' the entire table of accepted cover type codes, or it accepts filter parameter
 #' all=TRUE to return depreciated cover type codes too. No other filter
 #' parameters are currently available for this endpoint.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/cover_types
 #' for the full list of cover types
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -23,14 +23,14 @@
 #' @examples
 #'
 #' cover_types <- get_cover_types()
-#' all_cover_types <- get_cover_types(list(all=TRUE))
+#' all_cover_types <- get_cover_types(list(all = TRUE))
 #' cover_type_slugs <- get_cover_types(show_id = TRUE)
 get_cover_types <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("cover_types", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("cover_types", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/cover_types/%s",
     common_api_url,

--- a/R/get_credentials.R
+++ b/R/get_credentials.R
@@ -1,11 +1,40 @@
 #' Get GLIS Credentials
-#' 
-#' A helper function to prompt a user for their GLIS username and password.
-#' Using rstudioapi creates a pop-up to enter credentials so that usernames
-#' and passwords are not saved, and passwords are not visible.
+#'
+#' A helper function to prompt a user for their GLIS username and
+#' password.  The default function uses the rstudioapi which provides
+#' pop-up to enter credentials so that usernames and passwords are not
+#' saved, and passwords are not visible.  If the users is not using
+#' Rstudio, the default readline interface is used.  Depending on the
+#' R client, the password characters may not be obscured when the
+#' readlines function is called.
 
-get_credentials <- function(){
-  username <- rstudioapi::showPrompt(title = "Username", message = "Please enter your GLIS username (email):")
-  password <- rstudioapi::askForPassword(prompt = "Please enter your GLIS password:")
-  return(list(username=username, password=password))
+get_credentials <- function() {
+  rstudio_login <- function() {
+    username <- rstudioapi::showPrompt(
+      title = "Username",
+      message = "Please enter your GLIS username (email):"
+    )
+    password <- rstudioapi::askForPassword(
+      prompt = "Please enter your GLIS password:"
+    )
+    return(list(username = username, password = password))
+  }
+
+  fallback_login <- function() {
+    username <- readline("Please enter your GLIS username (email):")
+    password <- readline("Please enter your GLIS password:")
+    return(list(username = username, password = password))
+  }
+
+  credentials <- tryCatch(
+    {
+      rstudio_login()
+    },
+    error = function(e) {
+      fallback_login()
+    }
+  )
+
+
+  return(credentials)
 }

--- a/R/get_gears.R
+++ b/R/get_gears.R
@@ -1,6 +1,6 @@
 #' Get Gear List from the FN_Portal API
 #'
-#'  This function returns basic details about fishing gear(s) from the 
+#'  This function returns basic details about fishing gear(s) from the
 #'  FN_Prortal api. Use get_gear_process_types() for more detail about
 #'  the corresponding process type
 #'
@@ -23,7 +23,7 @@
 #' GL_n <- get_gear(list(gr = c("GL10", "GL21")))
 #' GL1x <- get_gear(list(gr__like = "GL1"))
 get_gear <- function(filter_list = list(), show_id = FALSE,
-                                   to_upper = TRUE) {
+                     to_upper = TRUE) {
   recursive <- ifelse(length(filter_list) == 0, FALSE, TRUE)
   query_string <- build_query_string(filter_list)
   check_filters("gear", filter_list, "fn_portal")

--- a/R/get_grid5s.R
+++ b/R/get_grid5s.R
@@ -1,16 +1,16 @@
 #' Get 5-minute grids - A list of 5-minute grids for the Great Lakes
 #'
 #' This function accesses the api endpoint for 5-minute grids and returns
-#' their number and the corresponding lake. It can fetch the entire table, 
+#' their number and the corresponding lake. It can fetch the entire table,
 #' or it accepts a filter parameter for lake. The filter parameters 'page'
 #' and 'page_size' are also accepted. No other filter
 #' parameters are currently available for this endpoint.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/grid5s
 #' for the full list of 5-minute grids
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -29,7 +29,7 @@ get_grid5s <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
   check_filters("grid5s", filter_list, "common")
-  
+
   my_url <- sprintf(
     "%s/grid5s/%s",
     common_api_url,

--- a/R/get_gruse.R
+++ b/R/get_gruse.R
@@ -3,13 +3,13 @@
 #' This function accesses the api endpoint for gear use choices and returns
 #' their labels, descriptions and whether they're in use. It fetches
 #' the entire table of gear use codes - no other filter
-#' parameters are currently available for this endpoint. 
-#' 
+#' parameters are currently available for this endpoint.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/gruse
 #' for the full list of gear use code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -26,9 +26,9 @@
 get_gruse <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("gruse", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("gruse", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/gruse/%s",
     common_api_url,

--- a/R/get_lakes.R
+++ b/R/get_lakes.R
@@ -1,15 +1,15 @@
 #' Get lakes - A list of lake names and abbreviations used in GLIS
 #'
 #' This function accesses the api endpoint for lake names and returns
-#' lake names and abbreviations. It is useful for fetching a table of 
-#' all lakes accepted by GLIS, but it also accepts the filter parameter 
-#' 'lake' to specify one or more lakes (by abbreviation) to fetch.  
-#' 
+#' lake names and abbreviations. It is useful for fetching a table of
+#' all lakes accepted by GLIS, but it also accepts the filter parameter
+#' 'lake' to specify one or more lakes (by abbreviation) to fetch.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/lakes
 #' for the full list of lakes
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -22,8 +22,8 @@
 #' @examples
 #'
 #' lake_list <- get_lakes()
-#' erie <- get_lakes(list(lake="ER"))
-#' upper_lakes <- get_lakes(list(lake=c("HU", "SU")))
+#' erie <- get_lakes(list(lake = "ER"))
+#' upper_lakes <- get_lakes(list(lake = c("HU", "SU")))
 get_lakes <- function(filter_list = list(), to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()

--- a/R/get_management_units.R
+++ b/R/get_management_units.R
@@ -20,7 +20,7 @@ get_management_units <- function(filter_list = list(), to_upper = TRUE) {
     common_api_url,
     query_string
   )
-  
+
   payload <- api_to_dataframe(my_url)
   payload <- prepare_payload(payload, to_upper = to_upper)
   return(payload)

--- a/R/get_prj_leads.R
+++ b/R/get_prj_leads.R
@@ -1,21 +1,21 @@
 #' Get project leads - A list of project leads used in GLIS
 #'
 #' This function accesses the api endpoint for project leads and returns
-#' their names and usernames. It can fetch the entire table of active project leads, 
+#' their names and usernames. It can fetch the entire table of active project leads,
 #' or it accepts the filter parameters to match all or part of a first name,
-#' last name, or username. 
-#' 
-#' 
+#' last name, or username.
+#'
+#'
 #'
 #' See
 #' http://10.167.37.157/fn_portal/api/v1/redoc/#tag/prj_ldr
-#' for a full list of available filter parameters. 
-#' 
+#' for a full list of available filter parameters.
+#'
 #' See
 #' http://10.167.37.157/common/project_leads
 #' for the full list of current and former staff that can be
 #' entered as a project lead.
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -28,13 +28,13 @@
 #' @examples
 #'
 #' prj_leads <- get_prj_leads()
-#' all_prj_leads <- get_prj_leads(list(all=TRUE))
-#' all_steves <- get_prj_leads(list(first_name__like = "ste", all=TRUE))
+#' all_prj_leads <- get_prj_leads(list(all = TRUE))
+#' all_steves <- get_prj_leads(list(first_name__like = "ste", all = TRUE))
 #' prj_lead_slugs <- get_prj_leads(show_id = TRUE)
 get_prj_leads <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   check_filters("prj_ldr", filter_list, "fn_portal")
-  
+
   my_url <- sprintf(
     "%s/prj_ldr/%s",
     get_fn_portal_root(),

--- a/R/get_pt_nr_milestones.R
+++ b/R/get_pt_nr_milestones.R
@@ -49,9 +49,9 @@ get_pt_nr_milestones <- function(filter_list = list(), to_upper = TRUE) {
     get_pt_portal_root(),
     query_string
   )
-  
+
   payload <- api_to_dataframe(my_url, recursive = recursive)
   payload <- prepare_payload(payload, to_upper = to_upper)
-  
+
   return(payload)
 }

--- a/R/get_pt_reports.r
+++ b/R/get_pt_reports.r
@@ -61,4 +61,3 @@ get_pt_reports <- function(filter_list = list(), to_upper = TRUE) {
 
   return(payload)
 }
-

--- a/R/get_species.R
+++ b/R/get_species.R
@@ -9,7 +9,7 @@
 #' See
 #' http://10.167.37.157/fn_portal/redoc/#operation/species_list_list
 #' for the full list of available filter keys (query parameters)
-#' 
+#'
 #'
 #' @param filter_list list
 #' @param to_upper - should the names of the dataframe be converted to
@@ -22,7 +22,7 @@
 #'
 #' species <- get_species()
 #' trout <- get_species(list(spc_nmco__like = "trout"))
-#' goby <- get_species(list(spc=366, detail=TRUE))
+#' goby <- get_species(list(spc = 366, detail = TRUE))
 get_species <- function(filter_list = list(), to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   check_filters("species", filter_list, "common")

--- a/R/get_tag_agencies.R
+++ b/R/get_tag_agencies.R
@@ -3,13 +3,13 @@
 #' This function accesses the api endpoint for orientation choices and returns
 #' their labels, descriptions and whether they're in use. It fetches
 #' the entire table of orientation codes - no other filter
-#' parameters are currently available for this endpoint. 
-#' 
+#' parameters are currently available for this endpoint.
+#'
 #'
 #' See
 #' http://10.167.37.157/common/orient
 #' for the full list of orientation code options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -26,9 +26,9 @@
 get_orientations <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("orient", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("orient", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/orient/%s",
     common_api_url,

--- a/R/get_tag_positions.R
+++ b/R/get_tag_positions.R
@@ -5,12 +5,12 @@
 #' the entire table of accepted tag positions - no other filter
 #' parameters are currently available for this endpoint. Tag position is the
 #' second character of TAGDOC.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/tag_postisions
 #' for the full list of tag position options
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -27,9 +27,9 @@
 get_tag_positions <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("tag_position", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("tag_position", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/tag_position/%s",
     common_api_url,

--- a/R/get_tag_types.R
+++ b/R/get_tag_types.R
@@ -6,12 +6,12 @@
 #' all=TRUE to return depreciated tag type choices too. No other filter
 #' parameters are currently available for this endpoint. Tag types are
 #' first character of TAGDOC.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/tag_types
 #' for the full list of tag types
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -24,14 +24,14 @@
 #' @examples
 #'
 #' tag_types <- get_tag_types()
-#' all_tag_types <- get_tag_types(list(all=TRUE))
+#' all_tag_types <- get_tag_types(list(all = TRUE))
 #' tag_slugs <- get_tag_types(show_id = TRUE)
 get_tag_types <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("tag_types", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("tag_types", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/tag_type_choice/%s",
     common_api_url,

--- a/R/get_taxon_table.R
+++ b/R/get_taxon_table.R
@@ -1,19 +1,19 @@
 #' Get taxon table - A list of fish and non-fish species and their ITIS taxon code
 #'
-#' This function accesses the api endpoint for taxon records of fish and 
+#' This function accesses the api endpoint for taxon records of fish and
 #' non-fish species. These records include the ITIS code, common name, scientific
-#' name, taxonomic rank, vert/invert classification, and HHFAU code (if applicable). 
+#' name, taxonomic rank, vert/invert classification, and HHFAU code (if applicable).
 #' Different taxonomic ranks allow selection of a taxon at different levels of
-#' specificity (e.g. 'Turtles/Testudines' vs. 'Eastern painted turtle'). 
-#' 
+#' specificity (e.g. 'Turtles/Testudines' vs. 'Eastern painted turtle').
+#'
 #' Current filter parameters are 'taxon', 'itiscode', 'taxon_name', 'taxon_label',
 #' 'taxonomic_rank', 'vertinvert', and 'omnr_provincial_code'.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/taxon
 #' for the full list of taxon codes
-#' 
+#'
 #'
 #' @param filter_list list
 #'

--- a/R/get_tissues.R
+++ b/R/get_tissues.R
@@ -5,12 +5,12 @@
 #' the entire table of accepted tissue codes, or it accepts filter parameter
 #' all=TRUE to return depreciated tissue codes too. No other filter
 #' parameters are currently available for this endpoint.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/tissues
 #' for the full list of tissues
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -23,14 +23,14 @@
 #' @examples
 #'
 #' tissues <- get_tissues()
-#' all_tissues <- get_tissues(list(all=TRUE))
+#' all_tissues <- get_tissues(list(all = TRUE))
 #' tissue_slugs <- get_tissues(show_id = TRUE)
 get_tissues <- function(filter_list = list(), show_id = FALSE, to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("tissues", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("tissues", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/tissue_samples/%s",
     common_api_url,

--- a/R/get_token.R
+++ b/R/get_token.R
@@ -1,5 +1,5 @@
 #' Get GLIS API token
-#' 
+#'
 #' A helper function to fetch a token from the GLIS API. The token is
 #' added to the GET request header. A new token is needed every 24 hours
 #' (or when the existing token is cleared from the Global Environment).
@@ -7,14 +7,13 @@
 #' @return string
 #' @export
 
-get_token <- function(){
-  
+get_token <- function() {
   body <- get_credentials()
-  
+
   r <- httr::POST("http://10.167.37.157/api-auth/token/", body = body)
   token <- httr::content(r)
-  
+
   assign("token", token, envir = .GlobalEnv)
-  
+
   print(token)
 }

--- a/R/get_vessels.R
+++ b/R/get_vessels.R
@@ -5,12 +5,12 @@
 #' the entire table of active vessels, or it accepts filter parameter
 #' all=TRUE to return depreciated vessels too. No other filter
 #' parameters are currently available for this endpoint.
-#' 
+#'
 #'
 #' See
 #' http://10.167.37.157/common/vessels
 #' for the full list of vessels
-#' 
+#'
 #'
 #' @param filter_list list
 #'
@@ -23,13 +23,13 @@
 #' @examples
 #'
 #' vessel_list <- get_vessels()
-#' all_vessels <- get_vessels(list(all=TRUE))
+#' all_vessels <- get_vessels(list(all = TRUE))
 get_vessels <- function(filter_list = list(), to_upper = TRUE) {
   query_string <- build_query_string(filter_list)
   common_api_url <- get_common_portal_root()
-  #check_filters("vessels", filter_list, "common")
-  #TODO: add a warning about 'all=TRUE' being the only allowed filter
-  
+  # check_filters("vessels", filter_list, "common")
+  # TODO: add a warning about 'all=TRUE' being the only allowed filter
+
   my_url <- sprintf(
     "%s/vessels/%s",
     common_api_url,

--- a/R/prepare_payload.R
+++ b/R/prepare_payload.R
@@ -27,11 +27,11 @@ prepare_payload <- function(payload, show_id = FALSE, to_upper = TRUE) {
   ) {
     payload <- subset(payload, select = -c(id, slug))
   }
-  
+
   if (show_id == FALSE &
-      !is.null(dim(payload)) &
-      !"id" %in% names(payload) &
-      "slug" %in% names(payload)
+    !is.null(dim(payload)) &
+    !"id" %in% names(payload) &
+    "slug" %in% names(payload)
   ) {
     payload <- subset(payload, select = -c(slug))
   }

--- a/R/show_filters.R
+++ b/R/show_filters.R
@@ -27,13 +27,12 @@
 #' show_filters("sc121", "cats")
 #' show_filters("foo")
 show_filters <- function(endpoint = "", filter_like = "") {
-  
   fn_portal_endpoints <- names(get_api_filters("fn_portal", FALSE))
   creels_endpoints <- names(get_api_filters("creels", FALSE))
   common_endpoints <- names(get_api_filters("common", FALSE))
   pt_endpoints <- names(get_api_filters("project_tracker", FALSE))
   all_endpoints <- do.call(c, list(fn_portal_endpoints, creels_endpoints, common_endpoints))
-  
+
   if (endpoint == "") {
     msg <-
       "An endpoint name needs to be provided. Currently available endpoint names are:\n"
@@ -42,11 +41,11 @@ show_filters <- function(endpoint = "", filter_like = "") {
   } else {
     endpoint <- tolower(endpoint)
     if (endpoint %in% fn_portal_endpoints) api_app <- "fn_portal"
-    if (endpoint %in% creels_endpoints) api_app <- "creels" 
+    if (endpoint %in% creels_endpoints) api_app <- "creels"
     if (endpoint %in% common_endpoints) api_app <- "common"
     if (endpoint %in% pt_endpoints) api_app <- "project_tracker"
     if (!endpoint %in% all_endpoints) stop("Oops, that endpoint is not valid. Run show_filters() for a list of valid endpoints.")
-    
+
     if (!exists("api_filters")) get_api_filters(api_app = api_app)
     filters <- api_filters[[endpoint]]
     if (is.null(filters)) {


### PR DESCRIPTION
This commit wraps the get_credentials function in a try catch - the Rstudioapi is used by default, but readlines is now used as a fallback if rstudioapi is not in use or available.  This commit also includes changes automatically performed by styler::style_pkg().  Virtually all of the changes made by styler were the removal of whitespace and the addition of line breaks.